### PR TITLE
Update CORS settings and add Netlify redirects

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -28,8 +28,7 @@ DEBUG = False
 ALLOWED_HOSTS = ['*']  # Em produção, especifique seus domínios
 
 CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",  # Vite local
-    "https://elevahub.netlify.app",  # Produção
+    "https://elevahub.netlify.app",
 ]
 CORS_ALLOW_ALL_ORIGINS = True  # Remova ou deixe explícito
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/api/*"
+  to = "https://<YOUR_RAILWAY_BACKEND_URL>/api/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
Modify CORS settings to allow requests from the production domain and configure redirects for API calls to the backend on Netlify.