### PR TITLE
Update API routing and Netlify redirects for internal environment

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -19,5 +19,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('nome_do_app.urls')),
+    path('api/', include('nome_do_app.urls')),  # Certifique-se de que 'nome_do_app' está correto
 ]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/api/*"
-  to = "https://test02-production.up.railway.app/api/:splat"
+  to = "https://test02.railway.internal/api/:splat"
   status = 200
   force = true

--- a/nome_do_app/urls.py
+++ b/nome_do_app/urls.py
@@ -31,4 +31,5 @@ router.register(r'codigos', views.CodigoEntradaViewSet, basename='codigoentrada'
 # o caminho 'api/', incluiremos todas as rotas geradas pelo 'router'.
 urlpatterns = [
     path('api/', include(router.urls)),
+    path('some-endpoint/', views.some_view, name='some_view'),  # Exemplo de endpoint
 ]


### PR DESCRIPTION
Adjust API routing in `urls.py` and modify Netlify redirects to point to the internal environment.