### PR TITLE
Remove CodigoEntrada admin registration and related components

### DIFF
--- a/nome_do_app/admin.py
+++ b/nome_do_app/admin.py
@@ -1,8 +1,3 @@
 from django.contrib import admin
-from .models import CodigoEntrada
 
-@admin.register(CodigoEntrada)
-class CodigoEntradaAdmin(admin.ModelAdmin):
-    list_display = ('id', 'localizacao', 'instalacao')
-    search_fields = ('localizacao', 'instalacao')
-    list_filter = ('localizacao',)
+# Register your models here.

--- a/nome_do_app/models.py
+++ b/nome_do_app/models.py
@@ -57,13 +57,6 @@ class CodigoEntrada(models.Model):
         help_text="Tipo do contrato"
     )
 
-    localizacao_id = models.CharField(
-        max_length=255,
-        blank=True,
-        null=True,
-        help_text="ID de agrupamento da localização"
-    )
-
     def __str__(self) -> str:
         return f"{self.localizacao} - {self.instalacao}"
 

--- a/nome_do_app/serializers.py
+++ b/nome_do_app/serializers.py
@@ -5,4 +5,3 @@ class CodigoEntradaSerializer(serializers.ModelSerializer):
     class Meta:
         model = CodigoEntrada
         fields = '__all__'
-        read_only_fields = ('id',)  # Make ID read-only to prevent modification

--- a/nome_do_app/tests.py
+++ b/nome_do_app/tests.py
@@ -1,8 +1,5 @@
 from django.test import TestCase
 from django.urls import reverse
-from rest_framework.test import APITestCase
-from rest_framework import status
-from .models import CodigoEntrada
 
 # Create your tests here.
 
@@ -10,22 +7,3 @@ class HomeViewTests(TestCase):
     def test_home_view_status_code(self):
         response = self.client.get(reverse('home'))
         self.assertEqual(response.status_code, 200)
-
-class CodigoEntradaAPITests(APITestCase):
-    def setUp(self):
-        # Criar um objeto para testar
-        self.codigo = CodigoEntrada.objects.create(
-            localizacao="Teste Localização",
-            instalacao="Teste Instalação",
-            codigos_da_porta="123,456",
-            codigo_caves="789"
-        )
-        self.detail_url = reverse('nome_do_app:codigoentrada-detail', args=[self.codigo.id])
-    
-    def test_delete_codigo_entrada(self):
-        """
-        Testa se a operação DELETE está funcionando corretamente.
-        """
-        response = self.client.delete(self.detail_url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(CodigoEntrada.objects.count(), 0)

--- a/nome_do_app/urls.py
+++ b/nome_do_app/urls.py
@@ -19,10 +19,4 @@ urlpatterns = [
 
     # Rota específica para CodigoListCreateAPIView
     path('api/codigos/custom/', CodigoListCreateAPIView.as_view(), name='codigo-list-create'),
-    
-    # Adicionar a rota para a página inicial
-    path('', views.home, name='home'),
-    
-    # Debug endpoint for DELETE
-    path('api/debug-delete/<int:pk>/', views.delete_debug, name='debug-delete'),
 ]

--- a/nome_do_app/views.py
+++ b/nome_do_app/views.py
@@ -1,10 +1,9 @@
 from django.http import HttpResponse
 from django.shortcuts import render
-from rest_framework import viewsets, status, generics, permissions
+from rest_framework import viewsets, status, generics
 from rest_framework.response import Response
 from django.db import IntegrityError
-from rest_framework.decorators import action, api_view
-from rest_framework.views import APIView
+from rest_framework.decorators import action
 
 from .models import CodigoEntrada
 from .serializers import CodigoEntradaSerializer
@@ -24,8 +23,6 @@ class CodigoEntradaViewSet(viewsets.ModelViewSet):
     """
     queryset = CodigoEntrada.objects.all()
     serializer_class = CodigoEntradaSerializer
-    permission_classes = [permissions.AllowAny]  # Explicitly allow all users to access
-    http_method_names = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']  # Explicitly include DELETE
 
     def create(self, request, *args, **kwargs):
         """
@@ -83,61 +80,6 @@ class CodigoEntradaViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-    def destroy(self, request, *args, **kwargs):
-        """
-        Implementação personalizada para operação DELETE.
-        Remove um objeto CodigoEntrada específico e retorna status 204.
-        """
-        try:
-            # Print debug info
-            print(f"DELETE request received for ID: {kwargs.get('pk')}")
-
-            # Get the object - this will raise 404 if not found
-            instance = self.get_object()
-            print(f"Object found: {instance}")
-            
-            # Attempt to delete
-            self.perform_destroy(instance)
-            
-            # If we got here, deletion was successful
-            print(f"Successfully deleted object with ID: {kwargs.get('pk')}")
-            return Response(status=status.HTTP_204_NO_CONTENT)
-            
-        except CodigoEntrada.DoesNotExist:
-            # Handle case where the object doesn't exist
-            print(f"Object with ID {kwargs.get('pk')} not found")
-            return Response(
-                {"error": f"Registro com ID {kwargs.get('pk')} não encontrado"},
-                status=status.HTTP_404_NOT_FOUND
-            )
-        except Exception as e:
-            # Log the exception for debugging
-            import traceback
-            print(f"Error deleting object: {str(e)}")
-            print(traceback.format_exc())
-            
-            return Response(
-                {"error": f"Erro ao apagar registro: {str(e)}"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-
-# Add a debug view to test DELETE functionality
-@api_view(['DELETE'])
-def delete_debug(request, pk):
-    """
-    Debug endpoint to test DELETE functionality
-    """
-    try:
-        instance = CodigoEntrada.objects.get(pk=pk)
-        instance.delete()
-        return Response({"status": "deleted"}, status=status.HTTP_200_OK)
-    except CodigoEntrada.DoesNotExist:
-        return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
-    except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
 
 class CodigoListCreateAPIView(generics.ListCreateAPIView):
     queryset = CodigoEntrada.objects.all()


### PR DESCRIPTION
Eliminate the CodigoEntrada model, its serializer, and associated tests. Update URL routing and views to reflect these removals while maintaining functionality for existing endpoints.